### PR TITLE
fixes for python3 packages and lightning-rod build

### DIFF
--- a/node-iotronic-lightning-rod/Makefile
+++ b/node-iotronic-lightning-rod/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 PKG_NPM_NAME:=iotronic-lightning-rod
 PKG_NAME:=node-$(PKG_NPM_NAME)
 PKG_VERSION:=2.3.9
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 PKG_ORG:=@mdslab
 
 PKG_SOURCE_PROTO:=git
@@ -17,7 +17,6 @@ PKG_HASH:=9909c665baf98a7e0a1056b0038270f4ddce4e87
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
 PKG_SOURCE_VERSION:=$(PKG_HASH)
 
-PKG_BUILD_DEPENDS:=node libc libpthread
 PKG_NODE_VERSION:=6.11.4
 PKG_USE_MIPS16:=0
 
@@ -38,9 +37,7 @@ endef
 
 NODEJS_CPU:=$(subst powerpc,ppc,$(subst aarch64,arm64,$(subst x86_64,x64,$(subst i386,ia32,$(ARCH)))))
 
-define Build/Prepare
-        $(INSTALL_DIR) $(PKG_BUILD_DIR)
-endef
+TARGET_CFLAGS += -I$(STAGING_DIR)/usr/include/fuse
 
 define Build/Compile
 	$(MAKE_VARS) \
@@ -50,7 +47,7 @@ define Build/Compile
 	npm_config_cache=$(TMP_DIR)/npm-cache \
 	npm_config_tmp=$(TMP_DIR)/npm-tmp \
 	PREFIX="$(PKG_INSTALL_DIR)/usr/" \
-	$(STAGING_DIR_HOSTPKG)/bin/npm install --build-from-source --target_arch=$(NODEJS_CPU) -g $(DL_DIR)/$(PKG_SOURCE)
+	$(STAGING_DIR_HOSTPKG)/bin/npm install --build-from-source --target_arch=$(NODEJS_CPU) -g $(PKG_BUILD_DIR)
 	rm -rf $(TMP_DIR)/npm-tmp
 	rm -rf $(TMP_DIR)/npm-cache
 endef
@@ -86,7 +83,7 @@ define Package/node-iotronic-lightning-rod/install
 	mkdir -p $(1)/var/log/iotronic/plugins
 	mkdir -p $(1)/etc/logrotate.d
 	touch $(1)/var/log/iotronic/lightning-rod.log
-	$(CP) $(1)/usr/lib/node_modules/$(PKG_ORG)/$(PKG_NPM_NAME)/etc/logrotate.d/lightning-rod.log $(1)/etc/logrotate.d/lightning-rod.log
+	# $(CP) $(1)/usr/lib/node_modules/$(PKG_ORG)/$(PKG_NPM_NAME)/etc/logrotate.d/lightning-rod.log $(1)/etc/logrotate.d/lightning-rod.log
 
 	# configure init.d 
 	$(INSTALL_DIR) $(1)/etc/init-cfg/

--- a/node-iotronic-lightning-rod/Makefile
+++ b/node-iotronic-lightning-rod/Makefile
@@ -7,13 +7,14 @@ include $(TOPDIR)/rules.mk
 PKG_NPM_NAME:=iotronic-lightning-rod
 PKG_NAME:=node-$(PKG_NPM_NAME)
 PKG_VERSION:=2.3.9
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 PKG_ORG:=@mdslab
 
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_URL:=ssh://git@git.smartme.io:20022/consulting/sacertis/iotronic-lightning-rod.git
 PKG_HASH:=9909c665baf98a7e0a1056b0038270f4ddce4e87
+PKG_SHORT_HASH:=9909c665
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-g$(PKG_SHORT_HASH).tar.gz
+PKG_SOURCE_URL:=ssh://git@git.smartme.io:20022/consulting/sacertis/iotronic-lightning-rod.git
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
 PKG_SOURCE_VERSION:=$(PKG_HASH)
 
@@ -28,7 +29,7 @@ define Package/node-iotronic-lightning-rod
   CATEGORY:=Languages
   TITLE:=Stack4Things Lightning-rod
   URL:=https://www.npmjs.org/package/iotronic-lightning-rod
-  DEPENDS:=+node +libfuse +libpthread +libc +gdb +node-lsof +patch
+  DEPENDS:=+node +libfuse +libpthread +libc +gdb +node-lsof +patch +logrotate
 endef
 
 define Package/node-iotronic-lightning-rod/description
@@ -62,7 +63,7 @@ define Package/node-iotronic-lightning-rod/install
 	chmod +x $(1)/usr/lib/node_modules/$(PKG_ORG)/$(PKG_NPM_NAME)/utils/install/arancino/*
 
 	# Configure IoTronic ENV
-	mkdir -p $(1)/var/lib/iotronic/
+	mkdir -p $(1)/var/lib/iotronic
 	mkdir -p $(1)/var/lib/iotronic/plugins
 	mkdir -p $(1)/var/lib/iotronic/drivers
 	
@@ -71,8 +72,8 @@ define Package/node-iotronic-lightning-rod/install
 	$(CP) ./files/patches/* $(1)/var/lib/iotronic/patches
 
 	mkdir -p $(1)/usr/bin
-	$(LN) /usr/lib/node_modules/@mdslab/iotronic-lightning-rod/utils/install/arancino/configure_LR_arancino.sh $(1)/usr/bin/configure_LR_arancino
-	$(LN) /usr/lib/node_modules/@mdslab/iotronic-lightning-rod/utils/install/arancino/board_bkp_rest.sh $(1)/usr/bin/board_bkp_rest
+	$(LN) $(1)/usr/lib/node_modules/@mdslab/iotronic-lightning-rod/utils/install/arancino/configure_LR_arancino.sh $(1)/usr/bin/configure_LR_arancino
+	$(LN) $(1)/usr/lib/node_modules/@mdslab/iotronic-lightning-rod/utils/install/arancino/board_bkp_rest.sh $(1)/usr/bin/board_bkp_rest
 
 	# Not overwrite settings.json
 	#$(CP) $(1)/usr/lib/node_modules/$(PKG_ORG)/$(PKG_NPM_NAME)/settings.example.json $(1)/var/lib/iotronic/settings.json
@@ -80,10 +81,11 @@ define Package/node-iotronic-lightning-rod/install
 	#$(CP) $(1)/usr/lib/node_modules/$(PKG_ORG)/$(PKG_NPM_NAME)/modules/drivers-manager/drivers.example.json $(1)/var/lib/iotronic/drivers/drivers.json
 
 	# Configure IoTronic Log
+	mkdir -p $(1)/var/log/iotronic
 	mkdir -p $(1)/var/log/iotronic/plugins
 	mkdir -p $(1)/etc/logrotate.d
 	touch $(1)/var/log/iotronic/lightning-rod.log
-	# $(CP) $(1)/usr/lib/node_modules/$(PKG_ORG)/$(PKG_NPM_NAME)/etc/logrotate.d/lightning-rod.log $(1)/etc/logrotate.d/lightning-rod.log
+	$(CP) ./files/etc/logrotate.d/lightning-rod.log $(1)/etc/logrotate.d/lightning-rod.log
 
 	# configure init.d 
 	$(INSTALL_DIR) $(1)/etc/init-cfg/
@@ -94,7 +96,7 @@ define Package/node-iotronic-lightning-rod/install
 	$(CP) ./files/etc/monit.d/* $(1)/etc/monit.d
 
 	# configure pluginExec
-	$(LN) /usr/lib/node_modules/@mdslab/iotronic-lightning-rod/utils/pluginExec/create_plugin_env $(1)/usr/bin/create_plugin_env
+	$(LN) $(1)/usr/lib/node_modules/@mdslab/iotronic-lightning-rod/utils/pluginExec/create_plugin_env $(1)/usr/bin/create_plugin_env
 
 
 endef

--- a/node-iotronic-lightning-rod/files/etc/logrotate.d/lightning-rod.log
+++ b/node-iotronic-lightning-rod/files/etc/logrotate.d/lightning-rod.log
@@ -1,0 +1,11 @@
+#/var/log/iotronic/lightning-rod.log
+/var/log/wstun/wstun.log{
+    copytruncate
+    missingok
+    weekly
+    rotate = 3
+    compress
+    notifempty
+    su root root
+    maxsize 5M
+}

--- a/node-iotronic-lightning-rod/patches/disabling-scripts.patch
+++ b/node-iotronic-lightning-rod/patches/disabling-scripts.patch
@@ -1,0 +1,25 @@
+diff --git a/package.json b/package.json
+index d19fa5a..107c31d 100644
+--- a/package.json
++++ b/package.json
+@@ -6,11 +6,6 @@
+   "directories": {
+     "doc": "docs"
+   },
+-  "scripts": {
+-    "test": "node lightning-rod.js",
+-    "postinstall": "./scripts/postinst",
+-    "uninstall": "./scripts/postuninst"
+-  },
+   "dependencies": {
+     "autobahn": "<=18.10.2",
+     "ws":"<=6.1.0",
+@@ -27,6 +22,8 @@
+     "python-shell":"0.5.0",
+     "net":"1.0.2",
+     "lsof":"0.1.0",
++	 "bufferutil":"3.0.4",
++	 "utf-8-validate":"4.0.1",
+     "cbor":"4.3.0"
+   },
+   "repository": {

--- a/node/Makefile
+++ b/node/Makefile
@@ -92,7 +92,7 @@ define Build/Prepare
 	$(call Build/Prepare/Default)
 	$(eval $(call Download,nodebin))
 	$(TAR) -xvf $(DL_DIR)/$(NODEJS) -C $(STAGING_DIR_HOSTPKG) --strip-components=1
-	$(STAGING_DIR_HOSTPKG)/bin/npm update npm -g $(STAGING_DIR_HOSTPKG)/lib/node_modules
+	$(STAGING_DIR_HOSTPKG)/bin/npm update npm@6.7.0 -g $(STAGING_DIR_HOSTPKG)/lib/node_modules
 endef
 
 define Build/InstallDev

--- a/python3-libxx-installer/Makefile
+++ b/python3-libxx-installer/Makefile
@@ -12,7 +12,7 @@ PKG_VERSION:=1.0
 PKG_RELEASE:=10
 
 include $(INCLUDE_DIR)/package.mk
-include $(TOPDIR)/feeds/packages/lang/python/python3-package.mk
+$(call include_mk, python3-package.mk)
 
 define Package/$(PKG_NAME)
   SUBMENU:=Python

--- a/python3-obspy-installer/Makefile
+++ b/python3-obspy-installer/Makefile
@@ -12,7 +12,7 @@ PKG_VERSION:=1.1.1
 PKG_RELEASE:=1
 
 include $(INCLUDE_DIR)/package.mk
-include $(TOPDIR)/feeds/packages/lang/python/python3-package.mk
+$(call include_mk, python3-package.mk)
 
 define Package/$(PKG_NAME)
   SUBMENU:=Python

--- a/python3-scixx-installer/Makefile
+++ b/python3-scixx-installer/Makefile
@@ -12,7 +12,7 @@ PKG_VERSION:=1.0
 PKG_RELEASE:=10
 
 include $(INCLUDE_DIR)/package.mk
-include $(TOPDIR)/feeds/packages/lang/python/python3-package.mk
+$(call include_mk, python3-package.mk)
 
 define Package/$(PKG_NAME)
   SUBMENU:=Python


### PR DESCRIPTION
This PR fixes the build macros for the following python3 packages :

- python3-libxx-installer
- python3-obspy-installer
- python3-scixx-installer

and in addition to this solve some critical node.js build errors :

- npm is updated to v6.7.0 for node.js v6 compatibility
- rework of node-iotronic-lightning-rod Makefile with these major modifications :
         - the source code is installed from **PKG_BUILD_DIR** as it should and not from the tarball
         - some dependencies (**utf-8-validate**, **bufferutil**) have been force for backwards compatibility with a local patch
         - **postinstall** script, and in general all the JSON **scripts** section, should be disabled when building the package
         - commented useless line where there is a wrong copy of the iotronic log file
